### PR TITLE
fix issue with alive check request

### DIFF
--- a/doipclient/client.py
+++ b/doipclient/client.py
@@ -44,7 +44,7 @@ class Parser:
     def read_message(self, data_bytes):
         self.rx_buffer += data_bytes
         if self._state == Parser.ParserState.READ_PROTOCOL_VERSION:
-            if self.rx_buffer:
+            if len(self.rx_buffer) >= 1:
                 self.payload = bytearray()
                 self.payload_type = None
                 self.payload_size = None
@@ -52,7 +52,7 @@ class Parser:
                 self._state = Parser.ParserState.READ_INVERSE_PROTOCOL_VERSION
 
         if self._state == Parser.ParserState.READ_INVERSE_PROTOCOL_VERSION:
-            if self.rx_buffer:
+            if len(self.rx_buffer) >= 1:
                 inverse_protocol_version = int(self.rx_buffer.pop(0))
                 if inverse_protocol_version != (0xFF ^ self.protocol_version):
                     logger.warning(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -452,6 +452,15 @@ def test_request_alive_check(mock_socket):
     assert mock_socket.tx_queue[-1] == alive_check_request
 
 
+def test_alive_check(mock_socket):
+    sut = DoIPClient(test_ip, test_logical_address)
+    mock_socket.rx_queue.append(alive_check_request)
+    with pytest.raises(TimeoutError):
+        sut.read_doip()
+    assert len(mock_socket.tx_queue) == 2
+    assert mock_socket.tx_queue[-1] == alive_check_response
+
+
 def test_request_entity_status_with_mds(mock_socket):
     sut = DoIPClient(test_ip, test_logical_address)
     mock_socket.rx_queue.append(entity_status_response_with_mds)


### PR DESCRIPTION
This pull request proposes a fix to an issue with an alive check request from the server.

Let's consider the following situation:
We are connected to a server, have sent a request to the server, and a waiting for the response from the server.
While we are waiting, the server sends an alive check request, which we should answer immediately.
--> To cover that situation, I have added the test "test_alive_check".

Running the test, we see that multiple alive_check_responses are sent, because the content of "data" is not cleared.
--> This can be fixed with the change in line 313

After the change, not even one alive_check_response is sent. This is because the request_alive_check message has zero payload size, but the parser always expects a nonzero payload size. (When the parser is in state `Parser.ParserState.READ_PAYLOAD`, there are no bytes left to be read from `self.rxbuffer` and the loop `while self.rxbuffer:` exits.)
--> This can be fixed by changing line 79 from `elif` to `if`.
That results in an if-elif-elif-if-block which looks inconsistent. So I decided to change all `elif` to `if` and to remove the loop.