### PR TITLE
Add classmethod get_entity to send Vehicle ID Req without TCP connect

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -25,6 +25,16 @@ Announcement broadcast message (sent at powerup) as follows:
     ip, port = address
     print(ip, port, logical_address)
 
+Alternatively, you can request a Vehicle Identification Response message:
+
+.. code-block:: python
+
+    from doipclient import DoIPClient
+    address, announcement = DoIPClient.get_entity()
+    logical_address = announcement.logical_address
+    ip, port = address
+    print(ip, port, logical_address)
+
 Once you have the IP address and Logical Address for your ECU, you can connect
 to it and begin interacting.
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -526,16 +526,47 @@ def test_request_vehicle_identification_with_ein(mock_socket):
     assert mock_socket.tx_queue[-1] == vehicle_identification_request_with_ein
     assert result.vin == "1" * 17
     assert result.logical_address == 0x1234
-    assert result.eid == b"1" * 6
-    assert result.gid == b"2" * 6
-    assert result.further_action_required == 0x00
-    assert result.vin_sync_status == 0x00
 
 
 def test_request_vehicle_identification_with_vin(mock_socket):
     sut = DoIPClient(test_ip, test_logical_address)
     mock_socket.rx_queue.append(vehicle_identification_response)
     result = sut.request_vehicle_identification(vin="1" * 17)
+    assert mock_socket.tx_queue[-1] == vehicle_identification_request_with_vin
+    assert result.vin == "1" * 17
+    assert result.logical_address == 0x1234
+    assert result.eid == b"1" * 6
+    assert result.gid == b"2" * 6
+    assert result.further_action_required == 0x00
+    assert result.vin_sync_status == 0x00
+
+def test_get_entity(mock_socket):
+    mock_socket.rx_queue.append(vehicle_identification_response)
+    _, result = DoIPClient.get_entity()
+    assert mock_socket.tx_queue[-1] == vehicle_identification_request
+    assert result.vin == "1" * 17
+    assert result.logical_address == 0x1234
+    assert result.eid == b"1" * 6
+    assert result.gid == b"2" * 6
+    assert result.further_action_required == 0x00
+    assert result.vin_sync_status == 0x00
+
+
+def test_get_entity_with_ein(mock_socket):
+    mock_socket.rx_queue.append(vehicle_identification_response)
+    _, result = DoIPClient.get_entity(eid=b"1" * 6)
+    assert mock_socket.tx_queue[-1] == vehicle_identification_request_with_ein
+    assert result.vin == "1" * 17
+    assert result.logical_address == 0x1234
+    assert result.eid == b"1" * 6
+    assert result.gid == b"2" * 6
+    assert result.further_action_required == 0x00
+    assert result.vin_sync_status == 0x00
+
+
+def test_get_entity_with_vin(mock_socket):
+    mock_socket.rx_queue.append(vehicle_identification_response)
+    _, result = DoIPClient.get_entity(vin="1" * 17)
     assert mock_socket.tx_queue[-1] == vehicle_identification_request_with_vin
     assert result.vin == "1" * 17
     assert result.logical_address == 0x1234


### PR DESCRIPTION
#17

```
addr, resp = DoIPClient.get_entity()
```

Binds to dynamically assigned port (UDP_TEST_EQUIPMENT_REQUEST) and sends to UDP_DISCOVERY port. Send IP defaults to broadcast, with the option to send unicast by passing in a IP address (IPV4 only for now)

Created a staticmethod to create the UDP socket that is used by `await_vehicle_announcement` and `get_entity`. Since the latter calls the former after sending the request, we reuse the socket.
