### PR TITLE
CI Python 3.6 + Windows Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         exclude:
-          - os: ubuntu-latest
+          - runs-on: ubuntu-latest
             python-version: 3.6
-          - os: ubuntu-20.04
+          - runs-on: ubuntu-20.04
             python-version: 3.12
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,10 +9,15 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest, ubuntu-20.04]
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        exclude:
+          - os: ubuntu-latest
+            python-version: 3.6
+          - os: ubuntu-20.04
+            python-version: 3.12
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, ubuntu-20.04]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         exclude:
           - os: ubuntu-latest
             python-version: 3.6
-          - os: ubuntu-20.04
-            python-version: 3.12
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, bring-back-python36 ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ main, bring-back-python36 ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,15 +8,15 @@ on:
 
 jobs:
   build:
-
-    runs-on: [ubuntu-latest, windows-latest, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, ubuntu-20.04]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         exclude:
-          - runs-on: ubuntu-latest
+          - os: ubuntu-latest
             python-version: 3.6
-          - runs-on: ubuntu-20.04
+          - os: ubuntu-20.04
             python-version: 3.12
 
     steps:


### PR DESCRIPTION
Switches to ubuntu 20.04 instead of ubuntu-latest for Python 3.6 testing. Added Windows images + Python 3.11