### PR TITLE
Fix for #36: default SSL context instead of preconfigured SSL context is used

### DIFF
--- a/doipclient/client.py
+++ b/doipclient/client.py
@@ -774,7 +774,7 @@ class DoIPClient:
             self._udp_sock.bind((self._client_ip_address, 0))
 
         if self._use_secure:
-            if isinstance(self._use_secure, type(ssl.SSLContext)):
+            if isinstance(self._use_secure, ssl.SSLContext):
                 ssl_context = self._use_secure
             else:
                 ssl_context = ssl.create_default_context()


### PR DESCRIPTION
Fix #36 

@alexeckle: You're right, `isinstance` has to check directly against `ssl.SSLContext`. I didn't pay enough attention when writing the tests, so the previous version checked against the mocked version of the SSLContext (which is incorrect).

Both the implementation and the tests are fixed with this PR.