### PR TITLE
Don't add the tests/ package to the distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/x-rst",
     author="Jacob Schaer",
     url="https://github.com/jacobschaer/python-doipclient",
-    packages=setuptools.find_packages(),
+    packages=['doipclient'],
     keywords=[
         "uds",
         "14229",


### PR DESCRIPTION
Currently, if you install python-doipclient, you get a `tests` package under `lib/python3.X/site-packages`. This became a problem to me, since I needed another `tests` package.