### PR TITLE
Fix "DeniedRequiresTLS" value for activation request

### DIFF
--- a/doipclient/messages.py
+++ b/doipclient/messages.py
@@ -399,7 +399,7 @@ class RoutingActivationResponse(DoIPMessage):
     ]
 
     class ResponseCode(IntEnum):
-        """See Table 48"""
+        """See Table 49"""
 
         DeniedUnknownSourceAddress = 0x00
         DeniedAllSocketsRegisteredActive = 0x01
@@ -407,7 +407,8 @@ class RoutingActivationResponse(DoIPMessage):
         DeniedSARegistered = 0x03
         DeniedMissingAuthentication = 0x04
         DeniedRejectedConfirmation = 0x05
-        DeniedRequiresTLS = 0x06
+        DeniedUnsupportedActivationType = 0x06
+        DeniedRequiresTLS = 0x07
         Success = 0x10
         SuccessConfirmationRequired = 0x11
 


### PR DESCRIPTION
Hi,
The value corresponding to a Negative Response "Requires TLS" after sending a Routing Activation Request is invalid.

Currently this value is set to "0x06", but according to the ISO-13400 standard, the "0x06" value corresponds to an unknown activation type.

Referring to the standard, we can state that the Negative Response Code "Requires TLS" should be set to "0x07" :

> After reception of a routing activation request message with a routing activation type, which requires the
> secure TLS connection to the DoIP entity then each DoIP entity supporting the secure TCP communication
> shall send the routing activation response message with the response code set to 0x07.

This patch applies the correct correction to the "DeniedRequiresTLS" value.

Sincerely,

Clément Ramirez