### PR TITLE
Added py.typed and setup.py support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/x-rst",
     author="Jacob Schaer",
     url="https://github.com/jacobschaer/python-doipclient",
-    packages=["doipclient"],
+    packages=["doipclient", "doipclient/py.typed"],
     keywords=[
         "uds",
         "14229",


### PR DESCRIPTION
I was getting errors from `mypy` when trying to use `doipclient`, and found the project is missing a `py.typed` file as described [here](https://blog.whtsky.me/tech/2021/dont-forget-py.typed-for-your-typed-python-package/).
