### PR TITLE
Exclude 3.7 from ubuntu-latest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,8 @@ jobs:
         exclude:
           - os: ubuntu-latest
             python-version: 3.6
+          - os: ubuntu-latest
+            python-version: 3.7
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, ubuntu-20.04]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           - os: ubuntu-latest
             python-version: 3.6


### PR DESCRIPTION
Seems ubuntu-latest no longer supports 3.7