### PR TITLE
some err will happen when suppress_positive_response=True in udsoncan

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,7 @@ using pytest::
 Example
 -------
 Updated version of udsoncan's example using `python_doip` instead of IsoTPSocketConnection
+if you want to use `suppress_positive_response=True`, please change `except TimeoutException:` to `except (TimeoutException, TimeoutError):` in `def send_request` of file `udsoncan/client.py` 
 
 .. code-block:: python
 


### PR DESCRIPTION
udsoncan except TimeoutException that is internal definition, but doipclient raise std err TimeoutError
![image](https://github.com/user-attachments/assets/d05397ce-ef60-4b32-92a2-1c441ee7e4bd)
